### PR TITLE
Fix subscribe

### DIFF
--- a/src/epubnub.erl
+++ b/src/epubnub.erl
@@ -234,12 +234,15 @@ request(Client, URLList, IsSSL) ->
         undefined ->
             Protocol = case IsSSL of
                            true ->
-                               <<"https:/">>;
+                               <<"https://">>;
                            false ->
-                               <<"http:/">>
+                               <<"http://">>
                        end,
-            URL = bin_join([Protocol | URLList], <<"/">>),
-            {ok, 200, _RespHeaders, Client1} = hackney:request(get, URL, [], <<>>, []);
+            [Host | Rest] = URLList,
+            Path = bin_join([<<"/">> | Rest], <<"/">>),
+            URL = <<Protocol/binary, Host/binary>>,
+            {ok, NewClient} = hackney:connect(URL),
+            {ok, 200, _RespHeaders, Client1} = hackney:send_request(NewClient, {get, Path, [], <<>>});
         Client ->
             Path = bin_join([<<"/">> | tl(URLList)], <<"/">>),
             {ok, 200, _RespHeaders, Client1} = hackney:send_request(Client, {get, Path, [], <<>>})

--- a/src/epubnub.erl
+++ b/src/epubnub.erl
@@ -241,7 +241,7 @@ request(Client, URLList, IsSSL) ->
             [Host | Rest] = URLList,
             Path = bin_join([<<"/">> | Rest], <<"/">>),
             URL = <<Protocol/binary, Host/binary>>,
-            {ok, NewClient} = hackney:connect(URL),
+            {ok, NewClient} = hackney:connect(URL, [{recv_timeout, infinity}]),
             {ok, 200, _RespHeaders, Client1} = hackney:send_request(NewClient, {get, Path, [], <<>>});
         Client ->
             Path = bin_join([<<"/">> | tl(URLList)], <<"/">>),


### PR DESCRIPTION
Right now subscribe is failing silently because calling `request` and `send_request` in sequence is returning an `{:error, :closed}` error, instead I've changed it to use `connect` for the first connection and `send_request` for all the request connections (following the examples in https://github.com/benoitc/hackney/blob/master/examples/test.ebin)

I've added also the `{recv_timeout, infinity}` option on connect in this way the socket will keep open until Pubnub sends data back.