### PR TITLE
Example client's channel should be a binary

### DIFF
--- a/src/epn_example_client.erl
+++ b/src/epn_example_client.erl
@@ -45,7 +45,7 @@ stop() ->
 
 %% @private
 init([EPN]) ->
-    {ok, PID} = epubnub_sup:subscribe(EPN, "hello_world", self()),
+    {ok, PID} = epubnub_sup:subscribe(EPN, <<"hello_world">>, self()),
     {ok, #state{pid=PID}}.
 
 %% @private


### PR DESCRIPTION
epubnub does a binary join, so it expects the channel to be a binary in order to create one larger, happy binary to send to hackney.